### PR TITLE
Upgrade to Newtonsoft 13.0.1

### DIFF
--- a/src/Hal9000.Test/Hal9000.Json.Net.Test.csproj
+++ b/src/Hal9000.Test/Hal9000.Json.Net.Test.csproj
@@ -37,9 +37,9 @@
     <Reference Include="Moq">
       <HintPath>..\packages\Moq.4.1.1309.0801\lib\net40\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version="12.0.3">
+    <Reference Include="Newtonsoft.Json, Version="13.0.1">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>

--- a/src/Hal9000/Hal9000.Json.Net.csproj
+++ b/src/Hal9000/Hal9000.Json.Net.csproj
@@ -34,9 +34,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version="12.0.3">
+    <Reference Include="Newtonsoft.Json, Version="13.0.1">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/HalWebApiExample/HalWebApiExample.csproj
+++ b/src/HalWebApiExample/HalWebApiExample.csproj
@@ -62,7 +62,7 @@
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http">
     </Reference>


### PR DESCRIPTION
This was done to quell Dependabot alerts about security vulnerabilities in Newtonsoft <13.0.1. This may not compile.